### PR TITLE
feat: Adicionar deploy manual para qualquer branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'main'
+        type: string
 
 env:
   AWS_REGION: us-east-1
@@ -47,11 +54,13 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.branch || github.ref }}
 
     - name: Download package
       uses: actions/download-artifact@v4

--- a/DEPLOY-AWS.md
+++ b/DEPLOY-AWS.md
@@ -37,7 +37,7 @@ aws sts get-caller-identity
    - `JWT_ISSUER`
    - `JWT_AUDIENCE`
 
-#### 2. Push para Deploy
+#### 2. Deploy Automático
 ```bash
 # Deploy automático para produção (apenas main)
 git push origin main
@@ -45,6 +45,13 @@ git push origin main
 # Para desenvolvimento, use dev (apenas build, sem deploy)
 git push origin dev
 ```
+
+#### 3. Deploy Manual (Qualquer Branch)
+1. Vá para **Actions** no GitHub
+2. Clique em **"Deploy to AWS"**
+3. Clique em **"Run workflow"**
+4. Escolha a branch desejada
+5. Clique em **"Run workflow"**
 
 ### **Opção 2: Deploy Manual**
 

--- a/GITHUB-SECRETS.md
+++ b/GITHUB-SECRETS.md
@@ -102,6 +102,11 @@ Para facilitar a renovação das credenciais, use os scripts:
 - **Pull Request para `main`** → Preview do deploy (comentário na PR)
 - **Push para `dev`** → Apenas build (sem deploy)
 
+### **Deploy Manual**
+- **Actions** → **Deploy to AWS** → **Run workflow**
+- Escolha a branch que deseja fazer deploy
+- Útil para testar outras branches ou fazer deploy sob demanda
+
 ### **Processo de Deploy**
 1. **Build** - Compila o projeto .NET
 2. **Package** - Cria o ZIP para Lambda


### PR DESCRIPTION
 Nova funcionalidade:

## Deploy Manual
-  Adicionado workflow_dispatch para deploy manual
-  Permite escolher qualquer branch para deploy
-  Mantém deploy automático apenas na main

## Como Usar
1. Vá para Actions  Deploy to AWS
2. Clique em 'Run workflow'
3. Escolha a branch desejada
4. Execute o deploy

## Triggers
- **Push para main**  Deploy automático
- **Deploy manual**  Qualquer branch
- **PR para main**  Preview

## Benefícios
- Testar outras branches sem fazer merge
- Deploy sob demanda
- Flexibilidade total de branches

Agora você pode fazer deploy da branch dev para testar o debug dos secrets!